### PR TITLE
Fix typo

### DIFF
--- a/activator.properties
+++ b/activator.properties
@@ -1,6 +1,6 @@
 name=reactive-kafka-scala
 title=Reactive Kafka with Scala
-description=Demonstrates Reactive Kafka for wrapping Apache Kafka as a reactive stram
+description=Demonstrates Reactive Kafka for wrapping Apache Kafka as a reactive stream
 tags=akka,scala,kafka,streams,sample
 
 authorName=SoftwareMill


### PR DESCRIPTION
"stram" to "stream" - shows up as first line after title in Typesafe Activator tutorial
